### PR TITLE
Fix libpng1.5/libng16 issues, keeping backword-compatible code, from Debian

### DIFF
--- a/xcf2png.c
+++ b/xcf2png.c
@@ -59,7 +59,14 @@ my_error_callback(png_structp png_ptr, png_const_charp errormsg)
   FatalUnexpected(_("Libpng error '%s'"),errormsg);
 }
 
-  
+#ifndef png_voidp_NULL
+#define png_voidp_NULL	NULL
+#endif
+
+#ifndef png_error_ptr_NULL
+#define png_error_ptr_NULL	NULL
+#endif
+
 static void
 init_output(void)
 {
@@ -71,9 +78,9 @@ init_output(void)
   
   outfile = openout(flatspec.output_filename);
   libpng = png_create_write_struct(PNG_LIBPNG_VER_STRING,
-                                   NULL,
+                                   png_voidp_NULL,
                                    my_error_callback,
-                                   NULL);
+                                   png_error_ptr_NULL);
   if( !libpng )
     FatalUnexpected(_("Couldn't initialize libpng library"));
   

--- a/xcf2png.c
+++ b/xcf2png.c
@@ -208,8 +208,11 @@ init_output(void)
 #endif
     break ;
   case PNG_COLOR_TYPE_GRAY:
-    png_set_filler(libpng,0,PNG_FILLER_AFTER);
+  {
+    // only supported with more than 8 bits, otherwise emit error: png_set_filler is invalid for low bit depth gray output'
+    if (bit_depth >= 8) png_set_filler(libpng,0,PNG_FILLER_AFTER);
     break ;
+  }
   case PNG_COLOR_TYPE_GRAY_ALPHA:
   case PNG_COLOR_TYPE_PALETTE:
     break ;


### PR DESCRIPTION
Two commits attached
