### PR TITLE
Fix testsuite when LC_ALL is set to UTF8, fixing recent Ubuntu build failures

### DIFF
--- a/test/dotest
+++ b/test/dotest
@@ -19,6 +19,7 @@
 
 export LC_CTYPE=C
 export LC_MESSAGES=C
+export LC_ALL=C
 
 : ${XCFTOOLS_PREFIX=../}
 


### PR DESCRIPTION
with

```
LANG=C.UTF-8
LC_ALL=C.UTF-8
```

I get testsuite failures:

```
 Version 0, 64x64 RGB color, 4 layers, compressed RLE
-- 10x10+27+27 RGB-alpha Normal AE=AE
+- 10x10+27+27 RGB-alpha Normal Æ=AE
```

this commit fixes the issue.
