### PR TITLE
Fix 'make' ignoring compiler detected by 'configure'

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -30,6 +30,7 @@ VERSION			= @PACKAGE_VERSION@
 APPNAME			= @PACKAGE_TARNAME@
 program_transform_name	= @program_transform_name@
 
+CC			= @CC@
 CFLAGS			= @CFLAGS@
 LDFLAGS			= @LDFLAGS@ @LIBICONV@
 LIBS			= @LIBS@


### PR DESCRIPTION
The Makefile.in is ignoring the compiler (@CC@) detected by the ./configure and defaulting to `cc`, this causes build failures on Guix.