### PR TITLE
Read file magic number to select unzipper, add xz compression support

### DIFF
--- a/io-unix.c
+++ b/io-unix.c
@@ -57,6 +57,7 @@ read_or_mmap_xcf(const char *filename,const char *unzipper)
     char bufmagic[2] ;
     char gzmagic[2] = { 0x1f, 0x8b } ;
     char bzmagic[2] = { 'B', 'Z' } ;
+    char xzmagic[2] = { 0xfd, '7' } ;
 
     xcfstream = fopen(filename,"rb") ;
     if( !xcfstream )
@@ -79,9 +80,10 @@ read_or_mmap_xcf(const char *filename,const char *unzipper)
         unzipper = "zcat" ;
       else if( memcmp(bufmagic, bzmagic, 2) == 0 )
         unzipper = "bzcat" ;
+      else if( memcmp(bufmagic, xzmagic, 2) == 0 )
+        unzipper = "xzcat" ;
       else
         unzipper = "" ;
-
     }
     else
       FatalUnexpected(_("!Could not read xcf file stat")) ;

--- a/io-unix.c
+++ b/io-unix.c
@@ -55,8 +55,11 @@ read_or_mmap_xcf(const char *filename,const char *unzipper)
 
   if( !unzipper ) {
     char bufmagic[2] ;
+    // 0x1f, 0x8b, 0x08; 8 for deflate
     char gzmagic[2] = { 0x1f, 0x8b } ;
+    // 'B', 'Z', 'h'; h for huffman
     char bzmagic[2] = { 'B', 'Z' } ;
+    // 0xfd, '7', 'z', 'X', 'Z'
     char xzmagic[2] = { 0xfd, '7' } ;
 
     xcfstream = fopen(filename,"rb") ;

--- a/io-unix.c
+++ b/io-unix.c
@@ -50,26 +50,46 @@ void
 read_or_mmap_xcf(const char *filename,const char *unzipper)
 {
   struct stat statbuf ;
-  
+
   free_or_close_xcf() ;
 
-  if( strcmp(filename,"-") != 0 ) {
-    if( access(filename,R_OK) != 0 )
-      FatalGeneric(21,"!%s",filename);
-  }
-
   if( !unzipper ) {
-    const char *pc ;
-    pc = filename + strlen(filename) ;
-    if( pc-filename > 2 && strcmp(pc-2,"gz") == 0 )
-      unzipper = "zcat" ;
-    else if ( pc-filename > 3 && strcmp(pc-3,"bz2") == 0 )
-      unzipper = "bzcat" ;
+    char bufmagic[2] ;
+    char gzmagic[2] = { 0x1f, 0x8b } ;
+    char bzmagic[2] = { 'B', 'Z' } ;
+
+    xcfstream = fopen(filename,"rb") ;
+    if( !xcfstream )
+      FatalGeneric(21,_("!Cannot open %s"),filename);
+
+    if( strcmp(filename,"-") != 0 )
+      if( access(filename,R_OK) != 0 )
+        FatalGeneric(21,"!%s",filename);
+
+    if( fstat(fileno(xcfstream),&statbuf) == 0 &&
+      (statbuf.st_mode & S_IFMT) == S_IFREG ) {
+      xcf_length = statbuf.st_size ;
+      if( xcf_length > 1 )
+        if( fread(bufmagic, 2, 1, xcfstream) == 0 )
+          FatalUnexpected(_("!Could not read xcf file")) ;
+      else
+        unzipper = "";
+
+      if( memcmp(bufmagic, gzmagic, 2) == 0 )
+        unzipper = "zcat" ;
+      else if( memcmp(bufmagic, bzmagic, 2) == 0 )
+        unzipper = "bzcat" ;
+      else
+        unzipper = "" ;
+
+    }
     else
-      unzipper = "" ;
+      FatalUnexpected(_("!Could not read xcf file stat")) ;
+
+    fclose(xcfstream) ;
   } else if( strcmp(unzipper,"cat") == 0 )
     unzipper = "" ;
-  
+
   if( *unzipper ) {
     int pid, status, outfd ;
 #if HAVE_MMAP


### PR DESCRIPTION
Hi, I had some commits living in my branch of `gnome-xcf-thumbnailer`:
https://gitlab.gnome.org/illwieckz/gnome-xcf-thumbnailer

It looks like `gnome-xcf-thumbnailer` just ships with an old copy of `xcftools`, so it's better to upstream the fixes.

One change is to not look at file extension to select the unzipper, but at the file magic number.

It may be undocumented (I have not checked) but GIMP supports loading compressed files having the `.xcf` extension.

One practical usage is that a contributor can store a new version of an XCF file in a repository without renaming it even if using a more modern compression than previous versions of the file. Some other formats meant for artists do the same like Blender `.blend` that can be compressed with gzip and stored as `.blend` as well.

So, it seems better to look at file magic number instead of extension to select the unzipper, also it would work even if the extension does not fit the content (like a bziped XCF having `.xcf.gz` extensions).

I also added support for xz compression. Newer version of GIMP ships by default with an option to produce `.xcf.xz` files.

One thing that is not supported, is the version 8 of the format, including the new in-format compression which is not an XCF in another compression container but some parts of the XCF file being compressed (with gzip if I'm right).